### PR TITLE
Update class-woocommerce.php

### DIFF
--- a/integrations/class-woocommerce.php
+++ b/integrations/class-woocommerce.php
@@ -73,7 +73,7 @@ class AffiliateWP_Store_Credit_WooCommerce extends AffiliateWP_Store_Credit_Base
 		$user_id    = affwp_get_affiliate_user_id( $referral->affiliate_id );
 
 		// Get the user's current woocommerce credit balance
-		$current_balance = get_user_meta( $user_id, 'affwp_wc_credit_balance', true );
+		$current_balance = (float) get_user_meta( $user_id, 'affwp_wc_credit_balance', true );
 
 		if ( $new_amount > $old_amount ) {
 			$new_balance = floatval( $current_balance + $new_amount );
@@ -139,7 +139,7 @@ class AffiliateWP_Store_Credit_WooCommerce extends AffiliateWP_Store_Credit_Base
 					$notice_subject,
 					wc_price( $balance ),
 					$notice_query,
-					add_query_arg( 'affwp_wc_apply_credit', 'true', WC()->cart->get_checkout_url() ),
+					add_query_arg( 'affwp_wc_apply_credit', 'true', wc_get_checkout_url() ),
 					$notice_action
 				),
 			'notice' );


### PR DESCRIPTION
(1) Cast $current_balance as (float) when retrieving it via get_user_meta. When the code runs before there is a current balance and the value 'false' is returned, that causes a php notice when used in a numeric calculation. Casting as (float) converts boolean false to numeric 0, and we avoid the php notice.

(2) Replace 'WC()->cart->get_checkout_url()' with 'wc_get_checkout_url()' when displaying the store credit notice. This avoids a woocommerce notice about 'WC()->cart->get_checkout_url()' being a deprecated method for getting the checkout url.